### PR TITLE
fix: Resolve strict-mode build errors

### DIFF
--- a/function/stable/sftp/SFTP_v1_main.ts
+++ b/function/stable/sftp/SFTP_v1_main.ts
@@ -16,13 +16,13 @@ export interface SftpFile {
  */
 export const SFTP_v1_listDirectory = (sftp: SFTPWrapper, remotePath: string): Promise<SftpFile[] | null> => {
     return new Promise((resolve) => {
-        sftp.readdir(remotePath, (err, list) => {
+        sftp.readdir(remotePath, (err: any, list: any) => {
             if (err) {
                 console.error(`[SFTP_v1_listDirectory] Error:`, err);
                 resolve(null);
                 return;
             }
-            const items = list.map(item => ({
+            const items = list.map((item: any) => ({
                 name: item.filename,
                 path: remotePath === '/' ? `/${item.filename}` : `${remotePath}/${item.filename}`,
                 type: item.longname.startsWith('d') ? 'folder' : 'file',
@@ -44,8 +44,8 @@ export const SFTP_v1_downloadFile = (sftp: SFTPWrapper, remotePath: string): Pro
     return new Promise((resolve) => {
         const stream = sftp.createReadStream(remotePath);
         const chunks: Buffer[] = [];
-        stream.on('data', (chunk) => chunks.push(chunk as Buffer));
-        stream.on('error', (err) => {
+        stream.on('data', (chunk: any) => chunks.push(chunk as Buffer));
+        stream.on('error', (err: any) => {
             console.error(`[SFTP_v1_downloadFile] Error:`, err);
             resolve(null);
         });

--- a/main/index.ts
+++ b/main/index.ts
@@ -77,7 +77,7 @@ app.whenReady().then(() => {
       const sessionId = `sftp-session-${Date.now()}`;
 
       client.on('ready', () => {
-        client.sftp((err, sftp) => {
+        client.sftp((err: any, sftp: any) => {
           if (err) {
             resolve({ success: false, error: err.message });
             return;
@@ -87,7 +87,7 @@ app.whenReady().then(() => {
         });
       });
 
-      client.on('error', (err) => {
+      client.on('error', (err: any) => {
         resolve({ success: false, error: err.message });
       });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/node": "^22.7.5",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@types/ssh2": "^1.15.5",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
         "@vitejs/plugin-react": "^4.2.0",
@@ -1593,6 +1594,33 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -12,24 +12,25 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "@types/node": "^22.7.5",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/ssh2": "^1.15.5",
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.19",
     "electron": "^30.0.1",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
     "postcss": "^8.4.38",
     "prettier": "^3.3.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.1.3",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.6.3",
-    "vite": "^5.0.0",
-    "@types/node": "^22.7.5"
+    "vite": "^5.0.0"
   },
   "dependencies": {
     "@google/genai": "^1.14.0",
@@ -37,11 +38,11 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.19.2",
+    "node-fetch": "^2.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.1.2",
     "ssh2": "^1.15.0",
-    "node-fetch": "^2.6.7",
     "ws": "^8.17.1",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0"


### PR DESCRIPTION
This commit fixes several TypeScript strict-mode compilation errors that were preventing the project from building successfully and causing the application to fail on launch.

The main application entry point (`dist/main/index.js`) was not being generated due to these errors.

Changes:
- Added `@types/ssh2` as a dev dependency to provide the necessary type definitions for the `ssh2` library.
- Added explicit `:any` types to parameters in `main/index.ts` and `function/stable/sftp/SFTP_v1_main.ts` to resolve implicit `any` errors under strict mode.

With these changes, the project now builds correctly with `npm run build`, and the application should launch as expected.