### PR TITLE
fix: Correct function names in preload script

### DIFF
--- a/main/preload.ts
+++ b/main/preload.ts
@@ -23,8 +23,8 @@ const electronAPI = {
     launchExternal: (path: string) => ipcRenderer.invoke('launcher:launchExternal', path),
   },
   appStore: {
-    discoverApps: () => ipcRenderer.invoke('appStore:discover'),
-    installApp: (app: any) => ipcRenderer.invoke('appStore:install', app),
+    discoverAvailableApps: () => ipcRenderer.invoke('appStore:discover'),
+    installExternalApp: (app: any) => ipcRenderer.invoke('appStore:install', app),
     getInstalledExternalApps: () => ipcRenderer.invoke('appStore:getInstalled'),
   },
   ssh: {


### PR DESCRIPTION
This commit fixes a runtime error where the App Store would fail to load. The error was caused by a naming mismatch between the functions defined in the `main/preload.ts` script and the functions called by the `AppStoreApp.tsx` component.

- Renamed `discoverApps` to `discoverAvailableApps`.
- Renamed `installApp` to `installExternalApp`.

This aligns the preload script with the frontend code and resolves the `is not a function` TypeError.